### PR TITLE
fix(aws-events-targets): StepFunctions doc & tests role usage

### DIFF
--- a/packages/@aws-cdk/aws-events-targets/README.md
+++ b/packages/@aws-cdk/aws-events-targets/README.md
@@ -167,13 +167,13 @@ const role = new iam.Role(this, 'Role', {
   assumedBy: new iam.ServicePrincipal('events.amazonaws.com'),
 });
 const stateMachine = new sfn.StateMachine(this, 'SM', {
-  definition: new sfn.Wait(this, 'Hello', { time: sfn.WaitTime.duration(cdk.Duration.seconds(10)) }),
-  role,
+  definition: new sfn.Wait(this, 'Hello', { time: sfn.WaitTime.duration(cdk.Duration.seconds(10)) })
 });
 
 rule.addTarget(new targets.SfnStateMachine(stateMachine, {
   input: events.RuleTargetInput.fromObject({ SomeParam: 'SomeValue' }),
   deadLetterQueue: dlq,
+  role: role
 }));
 ```
 


### PR DESCRIPTION
The role used in the example and test code needs to be passed to the SfnStateMachine target, not to the StateMachine resource.

The role's trust policy trusts events.amazonaws.com so the state machine resource would be unable to use this role anyways. Leave the StateMachine construct to create its own role. Instead, pass the role to SfnStateMachine where EventBridge will use it to start the state machine.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
